### PR TITLE
Update Graph-Database-Tinkerpop.md

### DIFF
--- a/Graph-Database-Tinkerpop.md
+++ b/Graph-Database-Tinkerpop.md
@@ -7,6 +7,13 @@ blueprints-core-*.jar
 orientdb-graphdb-*.jar 
 ```
 
+Also include the following 3rd party jars:
+```
+jna-*.jar
+jna-platform-*.jar
+concurrentlinkedhashmap-lru-*.jar
+```
+
 If you're connected to a remote server (not local/plocal/memory modes) include also:
 ```
 orientdb-client-*.jar


### PR DESCRIPTION
In my test program jna-*.jar was only necessary for plocal, not for remote.
jna-platform-*.jar was not necessary in my test program but it is mentioned in the table of jars in the section Java-API.
concurrentlinkedhashmap-lru-*.jar was always necessary.