### PR TITLE
improve layout by adding a space between link and what follows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - [3rd party Plugins](Plugins.md)
 - [Upgrade](Upgrade.md) 
 - [Configuration](Configuration.md)
-- [Distributed Architecture](Distributed-Architecture.md)(replication, sharding and high-availability)
+- [Distributed Architecture](Distributed-Architecture.md) (replication, sharding and high-availability)
 - [Performance Tuning](Performance-Tuning.md)
 - [ETL to Import any kind of data into OrientDB](ETL-Introduction.md)
 - [Import from Relational DB](Import-From-RDBMS.md)


### PR DESCRIPTION
cfr. other examples on the same page where there is a space between the link and what follows