### PR TITLE
Included command for installing Apache Ant with sample GratefulDeadCo…

### DIFF
--- a/Tutorial-Installation.md
+++ b/Tutorial-Installation.md
@@ -42,6 +42,12 @@ $ cd orientdb
 $ ant clean install
 ```
 
+In this tutorial, we use a sample database called *GratefulDeadConcerts*. Run the following command to have the *GratefulDeadConcerts* database installed with Apache Ant:
+
+``` console
+$ ant clean install -Dorientdb.test.env=ci
+```
+
 After the compilation, all the binaries are placed under the `../releases/` directory.
 
 #### Change Permissions


### PR DESCRIPTION
…ncerts database, which had been missing from the documentation.

This was first alluded to [in Issue #3605](https://github.com/orientechnologies/orientdb/issues/3605) but hadn't been updated in the docs.