### PR TITLE
Tutorial-Record-ID.md spelling correction

### DIFF
--- a/source/Tutorial-Record-ID.md
+++ b/source/Tutorial-Record-ID.md
@@ -9,7 +9,7 @@ In OrientDB each record has its own self-assigned unique ID within the database 
 That is,
 
 - `<cluster-id>` The cluster identifier.
-- `<cluster-position>` The position of hte data within the cluster.
+- `<cluster-position>` The position of the data within the cluster.
 
 Each database can have a maximum of 32,767 clusters, or 2<sup>15</sup> - 1.  Each cluster can handle up to 9,223,372,036,780,000 records, or 2<sup>63, namely 8,223,372 trillion records.
 


### PR DESCRIPTION
`hte` should be `the`

Only learned of OrientDB today and I was reading the docs when I came across this.
Incredibly small change but I figured I'd put a request in since it's your official docs.

I haven't read any contributing guidelines (since I suspect I won't be a regular contributor)
so I apologize if I made any mistakes in regards to the process, and feel free in rejecting
this PR