### PR TITLE
example in Sequences-and-auto-increment.md 

### DIFF
--- a/source/Sequences-and-auto-increment.md
+++ b/source/Sequences-and-auto-increment.md
@@ -96,8 +96,8 @@ This works in a SQL batch in this way:
 
 ```sql
 BEGIN
-let $counter = UPDATE counter INCREMENT value = 1 WHERE name = 'mycounter' return after
-INSERT INTO items SET id = $counter.value, qty = 10, price = 1000
+let $counter = UPDATE counter INCREMENT value = 1 return after $current WHERE name = 'mycounter'
+INSERT INTO items SET id = $counter.value[0], qty = 10, price = 1000
 COMMIT
 ```
 


### PR DESCRIPTION
Hello,
thanks for OrientDB.

the following example doesn't work: (tested on the OrientDB Server v2.1.2)
```
BEGIN
let $counter = UPDATE counter INCREMENT value = 1 WHERE name = 'mycounter' return after
INSERT INTO items SET id = $counter.value, qty = 10, price = 1000
COMMIT
```
error message:
```
 SEVER Internal server error:
com.orientechnologies.orient.core.sql.OCommandSQLParsingException: Error on parsing command at position #0: Encountered " <RETURN> "return "" at line 1, column 61.
Was expecting one of:
    <EOF> 
    <AND> ...
    <OR> ...
    <LIMIT> ...
    <TIMEOUT> ...
    <LOCK> ...
    ";" ...
     [ONetworkProtocolHttpDb]
```
I`m begginer,  but  I would like to propose a fix in this pull-request.