### PR TITLE
Add section about ORIENTDB_HOME

### DIFF
--- a/Embedded-Server.md
+++ b/Embedded-Server.md
@@ -136,3 +136,22 @@ public class OrientDBEmbeddable {
   }
 }
 ```
+
+## Setting ORIENTDB_HOME
+
+Some functionality wil not work properly if the system property 'ORIENTDB_HOME' is not set. You can set it programmatically like this:
+```java
+import com.orientechnologies.orient.server.OServerMain;
+
+public class OrientDBEmbeddable {
+
+  public static void main(String[] args) throws Exception {
+    String orientdbHome = new File("").getAbsolutePath(); //Set OrientDB home to current directory
+    System.setProperty("ORIENTDB_HOME", orientdbHome);
+
+    OServer server = OServerMain.create();
+    server.startup(cfg);
+    server.activate();
+  }
+}
+```


### PR DESCRIPTION
I had trouble with some features not working properly (specifically I got an error when autodeploy and hotalign was turned on. Se https://stackoverflow.com/questions/34352551/orientdb-trouble-creating-distributed-clusters-with-hotalignment-true/34398474). I suggest adding a small section explaining that this property is important, and how to set it programmatically.