### PR TITLE
Update SQL-Create-Function.md

### DIFF
--- a/SQL-Create-Function.md
+++ b/SQL-Create-Function.md
@@ -14,7 +14,7 @@ CREATE FUNCTION <name> <code>
 
 - **`<name>`** Defines the function name.
 - **`<code>`** Defines the function code.
-- **`PARAMETERS`** Defines a comma-separated list of parameters bound to the execution heap.
+- **`PARAMETERS`** Defines a comma-separated list of parameters bound to the execution heap. You must wrap your parameters list in square brackets [].
 - **`IDEMPOTENT`** Defines whether the function can change the database status.  This is useful given that HTTP GET can call `IDEMPOTENT` functions, while others are called by HTTP POST.  By default, it is set to `FALSE`.
 - **`LANGUAGE`** Defines the language to use.  By default, it is set to JavaScript.
 
@@ -24,6 +24,13 @@ CREATE FUNCTION <name> <code>
 
   <pre>
   orientdb> <code class="lang-sql userinput">CREATE FUNCTION test "print('\nTest!')"</code>
+  </pre>
+  
+  
+- Create a function `test(a,b)` in JavaScript, which takes 2 parameters:
+
+  <pre>
+  orientdb> <code class="lang-sql userinput">CREATE FUNCTION test "return a + b;" PARAMETERS [a,b]</code>
   </pre>
 
 - Create a function `allUsersButAdmin` in SQL, which takes with no parameters:


### PR DESCRIPTION
Using square brackets for the list is very confusing. It should probably be parenthesis because that is what you use when creating an index and need to specify a list of properties. However since that will probably never change because of backwards compatibility.

You need to specify that the square brackets are required because usually the square brackets indicate something optional which is where the current documentation is miss leading. I added a sentence to the syntax PARAMETERS description to help with this as well as added an example to help clarify.