### PR TITLE
Improve code example

### DIFF
--- a/Console-Commands.md
+++ b/Console-Commands.md
@@ -43,7 +43,7 @@ When the Console runs in batch mode, it takes commands as arguments on the comma
   <code class="lang-sql userinput">
     CONNECT REMOTE:localhost/demo;SELECT FROM Profile
   </code>
-  $ <code class="lang-sh userinput">$ORIENTDB_HOME/bin/console.sh commands.txt</code>
+  $ <code class="lang-sh userinput">$ORIENTDB_HOME/bin/console.sh < commands.txt</code>
   </pre>
 
 #### Ignoring Errors


### PR DESCRIPTION
It seems passing a textfile with commands as a parameter doesn't work (tested with 2.1.12) :

> console.sh commands.txt

What did work was piping the contents of the text file to the console command :

> console.sh < commands.txt