### PR TITLE
Make the installation prerequisites visible

### DIFF
--- a/Tutorial-Installation.md
+++ b/Tutorial-Installation.md
@@ -17,15 +17,6 @@ OrientDB is available in two editions:
 
 The Community Edition is available as a binary package for download or as source code on GitHub.  The Enterprise Edition license is included with [Support](http://orientdb.com/support/) purchases.
 
-## Use Docker
-
-If you have Docker installed in your computer, this is the easiest way to run OrientDB. From the command line type:
-
-    $ docker run -d –name orientdb -p 2424:2424 -p 2480:2480
-       -e ORIENTDB_ROOT_PASSWORD=root orientdb:latest
-
-Where instead of "root", type the root's password you want to use.
-
 
 **Prerequisites**
 
@@ -48,6 +39,15 @@ OrientDB requires [Java](http://www.java.com/en/download), version 1.7 or higher
 >```sh
 >$ java -Dorg.osgi.framework.system.packages.extra=sun.misc
 >```
+
+## Use Docker
+
+If you have Docker installed in your computer, this is the easiest way to run OrientDB. From the command line type:
+
+    $ docker run -d –name orientdb -p 2424:2424 -p 2480:2480
+       -e ORIENTDB_ROOT_PASSWORD=root orientdb:latest
+
+Where instead of "root", type the root's password you want to use.
 
 
 ### Binary Installation


### PR DESCRIPTION
It looks like that the prerequisites are a sub section of "Use Docker" while it is a prerequisites of orientdb itself. Therefor i swapped the positions of prerequisites and Use Docker.

Now the reading flow feels more correct to me. First  some prerequisites and than the suggested installation methods.