### PR TITLE
Corrected Docker command.

### DIFF
--- a/Tutorial-Installation.md
+++ b/Tutorial-Installation.md
@@ -26,7 +26,7 @@ The Community Edition is available as a binary package for download or as source
 
 If you have Docker installed in your computer, this is the easiest way to run OrientDB. From the command line type:
 
-    $ docker run -d –name orientdb -p 2424:2424 -p 2480:2480
+    $ docker run -d --name orientdb -p 2424:2424 -p 2480:2480
        -e ORIENTDB_ROOT_PASSWORD=root orientdb:latest
 
 Where instead of "root", type the root's password you want to use.


### PR DESCRIPTION
Per issue #6642 in the main OrientDB repo, on the Tutorial/Installation page, the "name" parameter for the Docker command was prefixed with a typographical dash, rather than the requisite double dashes. This pull request fixes this.