### PR TITLE
Fix typo in documentation (Transformer.md)

### DIFF
--- a/Transformer.md
+++ b/Transformer.md
@@ -445,7 +445,7 @@ Component description.
   { "log": {} }
   ```
 
-- Log the currnt value with `->` as the prefix:
+- Log the current value with `->` as the prefix:
 
   ```json
   { "log": 


### PR DESCRIPTION
Fix typo -- currnt is supposed to be current