### PR TITLE
Providing an SQL example for FetchPlans

### DIFF
--- a/Fetching-Strategies.md
+++ b/Fetching-Strategies.md
@@ -74,6 +74,15 @@ Under the default configuration, when a client executes a query or loads a singl
 
 When the client executes a query, set a Fetch Plan with a level different from `0`.  This causes the server to traverse all the records of the return result-set, sending them in response to a single call.  OrientDB loads all connected records into the local client, meaning that the collections remain lazy, but when accessing content, the record is loaded from the local cache to mitigate the need for additional connections.
 
+## Examples using SQL 
+
+Acquire Profile and it's first level friendships 
+
+```sql
+SELECT OUT("out_Friend") as friends FROM Profile fetchplan friends:1
+```
+This will provide a result set of Profile records with a field called `friends` that contains an array of verticies connected via a `out_Friend` edge. Only the `friends` field is apart of the fetchplan in this instance, any further will be treated as normal.  
+
 ## Examples using the Java APIs
 
 ### Execute a query with a custom fetch plan


### PR DESCRIPTION
I felt a general SQL example of using the FetchPlan was lacking amongst the java specific examples, of such an important feature