### PR TITLE
Update Windows-Service.md

### DIFF
--- a/Windows-Service.md
+++ b/Windows-Service.md
@@ -91,7 +91,7 @@ rem Install service
 OrientDBGraphX.X.X.exe //IS --DisplayName="OrientDB GraphEd X.X.X" ^
 --Description="OrientDB Graph Edition, aka GraphEd, contains OrientDB server integrated with the latest release of the TinkerPop Open Source technology stack supporting property graph data model." ^
 --StartClass=com.orientechnologies.orient.server.OServerMain --StopClass=com.orientechnologies.orient.server.OServerShutdownMain ^
---Classpath="%ORIENTDB_HOME%\lib\*" --JvmOptions=-Dfile.encoding=%ORIENTDB_ENCODING%;-Djava.util.logging.config.file="%LOG_FILE%";-Dorientdb.config.file="%CONFIG_FILE%";-Dorientdb.www.path="%WWW_PATH%";-Dlog.console.level=%LOG_CONSOLE_LEVEL%;-Dlog.file.level=%LOG_FILE_LEVEL%;-Dorientdb.build.number="@BUILD@";-DORIENTDB_HOME="%ORIENTDB_HOME%" ^
+--Classpath="%ORIENTDB_HOME%\lib\*;%ORIENTDB_HOME%\plugins\*" --JvmOptions=-Dfile.encoding=%ORIENTDB_ENCODING%;-Djava.util.logging.config.file="%LOG_FILE%";-Dorientdb.config.file="%CONFIG_FILE%";-Dorientdb.www.path="%WWW_PATH%";-Dlog.console.level=%LOG_CONSOLE_LEVEL%;-Dlog.file.level=%LOG_FILE_LEVEL%;-Dorientdb.build.number="@BUILD@";-DORIENTDB_HOME="%ORIENTDB_HOME%" ^
 --StartMode=jvm --StartPath="%ORIENTDB_HOME%\bin" --StopMode=jvm --StopPath="%ORIENTDB_HOME%\bin" --Jvm="%JVM_DLL%" --LogPath="%ORIENTDB_HOME%\log" --Startup=auto
 
 EXIT /B


### PR DESCRIPTION
Add "%ORIENTDB_HOME%\plugins\*" to "--Classpath" option for prevent errors like the following when start server as windows service.

```
2017-09-30 15:45:58:124 INFO  Installing dynamic plugin 'orientdb-etl-2.2.28.jar'... [OServerPluginManager]Error on installing dynamic plugin 'etl'
java.lang.ClassNotFoundException: com.orientechnologies.orient.etl.OETLPlugin
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at com.orientechnologies.orient.server.plugin.OServerPluginManager.startPluginClass(OServerPluginManager.java:270)
	at com.orientechnologies.orient.server.plugin.OServerPluginManager.installDynamicPlugin(OServerPluginManager.java:369)
	at com.orientechnologies.orient.server.plugin.OServerPluginManager.updatePlugin(OServerPluginManager.java:211)
	at com.orientechnologies.orient.server.plugin.OServerPluginManager.updatePlugins(OServerPluginManager.java:309)
	at com.orientechnologies.orient.server.plugin.OServerPluginManager.startup(OServerPluginManager.java:95)
	at com.orientechnologies.orient.server.OServer.registerPlugins(OServer.java:1202)
	at com.orientechnologies.orient.server.OServer.activate(OServer.java:406)
	at com.orientechnologies.orient.server.OServerMain$1.run(OServerMain.java:46)
```