### PR TITLE
Unsupported attributes and encryption for `cluster` in v3.1.x

### DIFF
--- a/security/Database-Encryption.md
+++ b/security/Database-Encryption.md
@@ -59,27 +59,7 @@ db.create();
 
 Whether you use the console or the Java API, these commands encrypt the entire database on disk.  OrientDB does not store the encryption key within the database.  You must provide it at run-time.
 
-## Encrypting Clusters
 
-In addition to the entire database, you can also only encrypt certain clusters on the database.  To do so, set the encryption to the default of `nothing` when you create the database, then configure the encryption per cluster through the [`ALTER CLUSTER`](../sql/SQL-Alter-Cluster.md) command. 
-
-To encrypt the cluster through the Java API, create the database, then alter the cluster to use encryption:
-
-```java
-ODatabaseDocumentTx db = new ODatabaseDocumentTx("plocal:/tmp/db/encrypted");
-db.setProperty(OGlobalConfiguration.STORAGE_ENCRYPTION_KEY.getKey(), "T1JJRU5UREJfSVNfQ09PTA==");
-db.create();
-db.command(new OCommandSQL("ALTER CLUSTER Salary encryption aes")).execute();
-```
-
-Bear in mind that the key remains the same for the entire database.  You cannot use different keys per cluster.  If you attempt to apply encryption or an encryption setting on a cluster that is not empty, it raises an error.
-
-To accomplish the same through the console, set the encryption key through `storage.encryptionKey` then define the encryption algorithm for the cluster:
-
-<pre>
-orientdb> <code class="lang-sql userinput">CONFIG SET storage.encryptionKey T1JJRU5UREJfSVNfQ09PTA==</code>
-orientdb> <code class="lang-sql userinput">ALTER CLUSTER Salary encryption aes</code>
-</pre>
 
 ## Opening Encrypted Databases
 
@@ -99,3 +79,4 @@ db.open("admin", "my_admin_password");
 
 In the event that you pass a null or invalid key when you open the database, OrientDB raises an `OSecurityException` exception.
 
+> **Note**: from version 3.x cluster encryption is no longer supported.

--- a/sql/SQL-Alter-Cluster.md
+++ b/sql/SQL-Alter-Cluster.md
@@ -62,11 +62,9 @@ ALTER CLUSTER <cluster> <attribute-name> <attribute-value>
 |---|---|---|---|
 | `NAME` | String | | Changes the cluster name. |
 | `STATUS`| String | | Changes the cluster status.  Allowed values are `ONLINE` and `OFFLINE`.  By default, clusters are online.  When offline, OrientDB no longer opens the physical files for the cluster.  You may find this useful when you want to archive old data elsewhere and restore when needed.|
-| `COMPRESSION` | String | | Defines the compression type to use.  Allowed values are `NOTHING`, `SNAPPY`, `GZIP`, and any other compression types registered in the `OCompressionFactory` class.  OrientDB class the `compress()` method each time it saves the record to the storage, and the `uncompress()` method each time it loads the record from storage.  You can also use the `OCompression` interface to manage encryption.|
-|`USE_WAL`| Boolean || Defines whether it uses the Journal (Write Ahead Log) when OrientDB operates against the cluster.|
-| `RECORD_GROW_FACTOR`|Integer| | Defines the grow factor to save more space on record creation.  You may find this useful when you update the record with additional information.  In larger records, this avoids defragmentation, as OrientDB doesn't have to find new space in the event of updates with more data.|
-|`RECORD_OVERFLOW_GROW_FACTOR`|Integer|| Defines grow factor on updates.  When it reaches the size limit, is uses this setting to get more space, (factor > 1).|
 |`CONFLICTSTRATEGY`|String|2.0+| Defines the strategy it uses to handle conflicts in the event that OrientDB MVCC finds an update or a delete operation it executes against an old record.  If you don't define a strategy at the cluster-level, it uses the database-level configuration.  For more information on supported strategies, see the section below.|
+
+> **Note**: from version 3.x attributes `COMPRESSION`, `USE_WAL`, `RECORD_OVERFLOW_GROW_FACTOR`, `RECORD_OVERFLOW_GROW_FACTOR` are no longer supported.
 
 ### Supported Conflict Strategies
 


### PR DESCRIPTION
- Unsupported attributes for `alter cluster` command
- Unsupported encryption on cluster level