### PR TITLE
Remove fetchplan description from OrientJS docs.

### DIFF
--- a/OrientJS-Query.md
+++ b/OrientJS-Query.md
@@ -47,40 +47,6 @@ db.query(
 });
 ```
 
-### Using Fetching Strategies
-
-While the `query()` method supports most OrientDB SQL statements, there are some limitations in regards to [Fetching Strategies](Fetching-Strategies.md).
-
-The `query()` method does not support Fetching Strategies directly.For instance, say that you want to query the player records in your baseball database with baseball card images.  From the OrientDB Console, you might issue this command:
-
-<pre>
-orientdb> <code class="lang-sql userinput">SELECT name, OUT("hasCard") AS cards
-          FROM Player FETCHPLAN *:1</code>
-</pre>
-
-This would return a result-set with the player's name in one colmn and an array from the `Card` class with all properties on that class, (as expected).  If instead, you passed this query in OrientJS through the `query()` method, you would meet with different results:
-
-```js
-db.query(
-   'SELECT name, OUT("hasCard") AS cards '
-   + 'FROM Player FETCHPLAN *:1')
-   .then(function(results){
-   console.log(results)
-})
-```
-
-Using this code, instead of fetching and unpacking the relationship connecting the `Player` and `Card` class, the `card` column would only contain an array of Record ID's, ignoring the Fetch Plan.  The reason is that it expects to parse Fetch Plans as part of a parameter option, rather than with the query itself.  To use Fetching Strategies with OrientJS, pass it as a parameter:
-
-```js
-var results = db.query(
-   'SELECT name, OUT("hasCard") AS cards '
-   + 'FROM Player',
-   {fetchPlan: 'hasCard:1'})
-    .then(function(results){
-   console.log(results)
-})
-```
-
 ## Query Builder
 
 Rather than writing out query strings in SQL, you can alternatively use the OrientJS Query Builder to construct queries using a series of methods connected through the Database API.


### PR DESCRIPTION
Fetch plan was deprecated in v3.0 (according to the Java API).