### PR TITLE
corrects the orientdb javadoc url

### DIFF
--- a/java/Java-API.md
+++ b/java/Java-API.md
@@ -3,7 +3,7 @@
 
 OrientDB is written completely in the Java language.  This means that you can use its Java API's without needing to install any additional drivers or adapters.
 
->For more information, see the [OrientDB Java Documentation](http://www.orientechnologies.com/javadoc/develop/)
+>For more information, see the [OrientDB Java Documentation](http://www.orientdb.com/javadoc/develop/)
 
 
 ## Component Architecture 


### PR DESCRIPTION
The URL to the Orientdb javadoc appears to be incorrect. This change fixes that.